### PR TITLE
fix: remove refresh token limit check[]

### DIFF
--- a/src/modules/identity/controllers/auth.controller.ts
+++ b/src/modules/identity/controllers/auth.controller.ts
@@ -62,8 +62,8 @@ export class AuthController {
   @ApiResponse({ status: 401, description: "Unauthorized" })
   async login(@Body() payload: LoginPayload, @Res() res: FastifyReply) {
     const user = await this.authService.validateUser(payload);
-
-    await this.authService.checkRefreshTokenSize(user);
+    // Removing refresh token limit check until refresh token flow is fixed - Nayan (Feb 28, 2024)
+    // await this.authService.checkRefreshTokenLimit(user);
 
     const tokenPromises = [
       this.authService.createToken(user._id),
@@ -136,7 +136,8 @@ export class AuthController {
     if (isUserExists) {
       id = isUserExists._id;
       this.contextService.set("user", isUserExists);
-      await this.authService.checkRefreshTokenSize(isUserExists);
+      // Removing refresh token limit check until refresh token flow is fixed - Nayan (Feb 28, 2024)
+      // await this.authService.checkRefreshTokenLimit(isUserExists);
     } else {
       const user = await this.userService.createGoogleAuthUser(
         oAuthId,

--- a/src/modules/identity/controllers/test/auth.controller.spec.ts
+++ b/src/modules/identity/controllers/test/auth.controller.spec.ts
@@ -63,7 +63,7 @@ describe("AuthController", () => {
   let mockFastifyReply: FastifyReply;
   const authServiceMock = {
     validateUser: jest.fn().mockResolvedValue(UserDetails),
-    checkRefreshTokenSize: jest.fn().mockResolvedValue(null),
+    checkRefreshTokenLimit: jest.fn().mockResolvedValue(null),
     createToken: jest.fn().mockResolvedValue(TokenResponse),
     createRefreshToken: jest.fn().mockResolvedValue(TokenResponse),
     validateRefreshToken: jest.fn().mockResolvedValue(TokenResponse),

--- a/src/modules/identity/repositories/user.repository.ts
+++ b/src/modules/identity/repositories/user.repository.ts
@@ -160,11 +160,12 @@ export class UserRepository {
     _id: ObjectId,
     refreshToken: string,
   ): Promise<void> {
+    // Replacing old refresh tokens with the new token until refresh token flow is fixed. - Nayan (Feb 28,2024)
     await this.db.collection<User>(Collections.USER).findOneAndUpdate(
       { _id },
       {
-        $push: {
-          refresh_tokens: refreshToken,
+        $set: {
+          refresh_tokens: [refreshToken],
         },
       },
     );

--- a/src/modules/identity/services/auth.service.ts
+++ b/src/modules/identity/services/auth.service.ts
@@ -198,7 +198,7 @@ export class AuthService {
     };
   }
 
-  async checkRefreshTokenSize(user: User): Promise<void> {
+  async checkRefreshTokenLimit(user: User): Promise<void> {
     if (user.refresh_tokens.length === this.refreshTokenMaxLimit) {
       throw new BadRequestException("Maximum request limit reached");
     }


### PR DESCRIPTION
## Description

This PR removes the refresh token limit check until the flow is fixed on frontend.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [ ] 👍 yes
- [ ] 🙅 no, because I am lazy

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
## Related Story, task & Documents?
