### PR TITLE
fix: new team image upload size to 2MB

### DIFF
--- a/src/modules/common/config/configuration.ts
+++ b/src/modules/common/config/configuration.ts
@@ -10,7 +10,7 @@ export default () => ({
     defaultWorkspaceName: "My Workspace",
     userBlacklistPrefix: "BL_",
     defaultTeamNameSuffix: "'s Team",
-    imageSizeLimit: 102400,
+    imageSizeLimit: 2097152, // value in byte
     deletedAPILimitInDays: 7,
     timeToDaysDivisor: 86400000,
     kafkaHitTimeInterval: 3000,

--- a/src/modules/identity/services/team.service.ts
+++ b/src/modules/identity/services/team.service.ts
@@ -38,7 +38,7 @@ export class TeamService {
     if (size < this.configService.get("app.imageSizeLimit")) {
       return true;
     }
-    throw new BadRequestException("Image size should be less than 100kb");
+    throw new BadRequestException("Image size should be less than 2MB");
   }
 
   /**


### PR DESCRIPTION
## Description
fix: new team image upload size to 2MB

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [x] 👍 yes
- [ ] 🙅 no, because I am lazy

