### PR TITLE
fix: remove validation for duplicate team with same name [#1189]

### DIFF
--- a/src/modules/identity/repositories/team.repository.ts
+++ b/src/modules/identity/repositories/team.repository.ts
@@ -39,10 +39,7 @@ export class TeamRepository {
     teamData: CreateOrUpdateTeamDto,
   ): Promise<InsertOneResult<Team>> {
     const user = this.contextService.get("user");
-    const exists = await this.doesTeamExistsForUser(user._id, teamData.name);
-    if (exists) {
-      throw new BadRequestException("The Team with that name already exists.");
-    }
+
     const params = {
       users: [
         {


### PR DESCRIPTION
## Description
This pull request removes the validation check that prevents the creation of teams with duplicate names. This change is being made to allow for more flexibility in team naming, acknowledging that different departments  might have teams that share the same name.

fixes #1189

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [x] 👍 yes
- [ ] 🙅 no, because I am lazy


