### PR TITLE
fix: handle cancel event google auth

### DIFF
--- a/src/modules/common/guards/google-oauth.guard.ts
+++ b/src/modules/common/guards/google-oauth.guard.ts
@@ -1,9 +1,14 @@
-import { Injectable } from "@nestjs/common";
+import { ExecutionContext, Injectable } from "@nestjs/common";
 import { AuthGuard } from "@nestjs/passport";
 
 @Injectable()
 export class GoogleOAuthGuard extends AuthGuard("google") {
-  constructor() {
-    super();
+  handleRequest(err: string, user: any, info: any, context: ExecutionContext) {
+    const request = context.switchToHttp().getRequest();
+    const error = request.query.error;
+    if (error) {
+      return error;
+    }
+    return user;
   }
 }

--- a/src/modules/identity/controllers/auth.controller.ts
+++ b/src/modules/identity/controllers/auth.controller.ts
@@ -142,6 +142,17 @@ export class AuthController {
   })
   @UseGuards(GoogleOAuthGuard)
   async googleCallback(@Req() req: any, @Res() res: FastifyReply) {
+    if (req.user === "access_denied") {
+      const url = encodeURI(this.configService.get("oauth.google.redirectUrl"));
+      const urlWithToken = `${url}?accessToken=&refreshToken=`;
+      const urlWithTokenAndSource = urlWithToken + "&source=";
+
+      return res.redirect(
+        HttpStatusCode.MOVED_PERMANENTLY,
+        urlWithTokenAndSource,
+      );
+    }
+
     const { oAuthId, name, email } = req.user;
     const isUserExists = await this.userService.getUserByEmail(email);
     let id: ObjectId;


### PR DESCRIPTION
## Description
to handling access_denied, the Google OAuth process can be modified to detect a cancellation event if Google redirects back with an error query parameter. Typically, the access_denied error is equivalent to a cancel action if the user decides not to proceed with the Google OAuth.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build

## Have you tested locally?

- [x] 👍 yes
- [ ] 🙅 no, because I am lazy

