### PR TITLE
feat: User Name is not showing at magic code otp page [#2278]

### DIFF
--- a/src/modules/identity/controllers/user.controller.ts
+++ b/src/modules/identity/controllers/user.controller.ts
@@ -191,10 +191,11 @@ export class UserController {
     @Body() emailPayload: EmailPayload,
     @Res() res: FastifyReply,
   ) {
-    await this.userService.sendMagicCodeEmail(emailPayload);
+    const user = await this.userService.getUserByEmail(emailPayload.email);
     const responseData = new ApiResponseService(
       "Email Sent Successfully",
       HttpStatusCode.OK,
+      user.name,
     );
     return res.status(responseData.httpStatusCode).send(responseData);
   }


### PR DESCRIPTION
Users name is missing in send magic code state #2278 
 [#2278](https://github.com/sparrowapp-dev/sparrow-app/issues/2278)
1.Enter previously used email.
2.Click on send magic code
Expected-
      
![image](https://github.com/user-attachments/assets/ccb8beb2-7752-49df-9285-d23b68a53832)

Actual-
![image](https://github.com/user-attachments/assets/36595a92-0797-4faf-82cc-1b2ce8a9f23f)

after solving the bug  we get 
![image](https://github.com/user-attachments/assets/a3f4bcd2-b40f-4b7f-9ce0-f9af0f9ac2d7)

