### PR TITLE
fix: pushed default key value pair in collection import []

### DIFF
--- a/src/modules/common/services/helper/oapi3.transformer.ts
+++ b/src/modules/common/services/helper/oapi3.transformer.ts
@@ -120,12 +120,7 @@ function transformPathV3(
       value: "",
       checked: false,
     };
-    const formDataFileDefaultObj = {
-      key: "",
-      value: "",
-      checked: false,
-      base: "",
-    };
+
     const transformedObject: TransformedRequest = {
       name: pathName || "",
       description: "",
@@ -360,21 +355,10 @@ function transformPathV3(
     }
 
     //Assign default values
-    if (!transformedObject.request.headers.length) {
-      transformedObject.request.headers.push(keyValueDefaultObj);
-    }
-    if (!transformedObject.request.queryParams.length) {
-      transformedObject.request.queryParams.push(keyValueDefaultObj);
-    }
-    if (!transformedObject.request.body.formdata.text.length) {
-      transformedObject.request.body.formdata.text.push(keyValueDefaultObj);
-    }
-    if (!transformedObject.request.body.formdata.file.length) {
-      transformedObject.request.body.formdata.file.push(formDataFileDefaultObj);
-    }
-    if (!transformedObject.request.body.urlencoded.length) {
-      transformedObject.request.body.urlencoded.push(keyValueDefaultObj);
-    }
+    transformedObject.request.headers.push(keyValueDefaultObj);
+    transformedObject.request.queryParams.push(keyValueDefaultObj);
+    transformedObject.request.body.formdata.text.push(keyValueDefaultObj);
+    transformedObject.request.body.urlencoded.push(keyValueDefaultObj);
     transformedObjectArray.push(transformedObject);
   }
 

--- a/src/modules/common/services/helper/postman.parser.ts
+++ b/src/modules/common/services/helper/postman.parser.ts
@@ -320,11 +320,18 @@ function mapKeyValuePairs(data: any[]): KeyValue[] {
 function convertParams(params: any[]): KeyValue[] {
   if (!params || !params.length)
     return [{ key: "", value: "", checked: false }];
-  return params.map((param) => ({
+  const convertedParams = params.map((param) => ({
     key: param.key || param.name || "",
     value: param.value || "",
     checked: false,
   }));
+  // Pushed extra empty key values.
+  convertedParams.push({
+    key: "",
+    value: "",
+    checked: false,
+  });
+  return convertedParams;
 }
 
 /**


### PR DESCRIPTION
### Description
In this PR i have pushed the default key value pair for every import of collection like swagger and  postman import. 
It will fix the issue of imported collection tabs becoming unsaved at open. 

### Add Issue Number
Fixes #<your_issue_number>

### Add Screenshots/GIFs
If applicable, add relevant screenshot/gif here.

### Add Known Issue
If applicable, add any known issues.

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.