### PR TITLE
fix: restricted slug limit to 50 characters and removed unique name check [SPRW-558]

### DIFF
--- a/src/modules/identity/services/team.service.ts
+++ b/src/modules/identity/services/team.service.ts
@@ -54,7 +54,10 @@ export class TeamService {
     const suffix = ".sparrowhub.net";
     // const envPath =
     //   this.configService.get("app.env") === Env.PROD ? "/release/v1" : "/dev";
-    const base = this.sanitizeName(name);
+    let base = this.sanitizeName(name);
+    if (base.length > 50) {
+      base = base.slice(0, 50);
+    }
     const baseUrl = `${prefix}${base}`;
 
     const regexPattern = `^${baseUrl}\\d*${suffix}$`;
@@ -87,12 +90,6 @@ export class TeamService {
     image?: MemoryStorageFile,
   ): Promise<InsertOneResult<Team>> {
     let team;
-    const isTeamExist = await this.teamRepository.isTeamNameAvailable(
-      teamData.name,
-    );
-    if (!isTeamExist && !teamData?.firstTeam) {
-      throw new BadRequestException("Team with this name already exist.");
-    }
 
     const dynamicUrl = await this.generateUniqueTeamUrl(teamData.name);
     if (image) {


### PR DESCRIPTION


### Description
In this PR i have restricted the length of hub url slug to 50 characters because as per RFC rule the subdomain can only be of 63 characters. 
Removed the unique name check. 

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.