### PR TITLE
fix: postman collection import

### DIFF
--- a/src/modules/common/services/postman.parser.service.ts
+++ b/src/modules/common/services/postman.parser.service.ts
@@ -30,7 +30,8 @@ export class PostmanParserService {
     const user = await this.contextService.get("user");
 
     // Destructure the 'info' and 'item' properties from the Postman collection
-    const { info, item: items } = postmanCollection;
+    const { info, item: items } =
+      postmanCollection.collection ?? postmanCollection;
 
     // Convert the items of the Postman collection into a specific format
     // Majorly responsible for converting the folder and request structure of postman into Sparrow's structure


### PR DESCRIPTION
### Description
Postman's recent change to its collection JSON structure caused the import Postman collection API in Sparrow to break. This pull request resolves the issue by aligning the import functionality with the new JSON format.

### Add Issue Number

### Add Screenshots/GIFs
![Screenshot 2025-04-23 at 11 27 03 AM](https://github.com/user-attachments/assets/e2715dcb-bff1-4fda-b7b3-73d7009cff30)

### Add Known Issue
No known issues.

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.