### PR TITLE
fix: workspaces issue with admin panel restricted view support SPRW-2754.

### DIFF
--- a/src/modules/billing/services/downgrade.service.ts
+++ b/src/modules/billing/services/downgrade.service.ts
@@ -275,23 +275,44 @@ export class DownGradeService {
   async disableAutoDowngrade(
     teamId: string,
     workspaces: WorkspaceDtoWithRestriction[],
-    newPlan:PlanName,
+    newPlan: PlanName,
   ) {
     try {
       await this.stripeSubscriptionRepository.disableAutoDowngrade(teamId);
-      const teamPlan = await this.stripeSubscriptionRepository.findPlanByName(newPlan);
+      const teamPlan =
+        await this.stripeSubscriptionRepository.findPlanByName(newPlan);
       const planLimitWorkspaces = teamPlan.limits.workspacesPerHub.value || 3;
       if (workspaces.length > planLimitWorkspaces) {
         // Split workspaces into allowed and to-be-removed
-        const allowedWorkspaces = workspaces.slice(0, planLimitWorkspaces);
-        // Get IDs for allowed workspaces (set restriction to false)
-        const allowedWorkspaceIds = allowedWorkspaces.map((workspace) =>
+        const workspaceIds = workspaces.map((workspace) =>
           workspace.id.toString(),
         );
         // Enable only the allowed workspaces (set restriction = false)
         await this.downgradeWorkspaceReposiory.setMultipleWorkspaceRestrictions(
-          allowedWorkspaceIds,
+          workspaceIds,
           false,
+        );
+        // Get only the workspaces beyond the allowed plan limit
+        const remainingWorkspaces = workspaces.slice(planLimitWorkspaces);
+        // Mark those as restricted = true before updating
+        for (const workspace of remainingWorkspaces) {
+          await this.downgradeWorkspaceReposiory.setWorkspaceRestriction(
+            workspace.id.toString(),
+            true,
+          );
+          workspace.isRestricted = true;
+        }
+        // Build updated list: allowed stay as-is, remaining now marked restricted
+        const updatedWorkspaces = [
+          ...workspaces.slice(0, planLimitWorkspaces), // allowed ones
+          ...remainingWorkspaces, // already modified above
+        ];
+        const teamUpdated = {
+          workspaces: updatedWorkspaces,
+        };
+        await this.downgradeTeamRepository.updateTeamById(
+          new ObjectId(teamId),
+          teamUpdated,
         );
       } else {
         // All workspaces are within the limit, disable restrictions for all

--- a/src/modules/billing/services/stripe-subscription.service.ts
+++ b/src/modules/billing/services/stripe-subscription.service.ts
@@ -655,6 +655,11 @@ export class StripeSubscriptionService {
         updateTeam,
         metadata.hubId,
       );
+      await this.downgradeService.disableAutoDowngrade(
+        metadata.hubId,
+        team?.workspaces,
+        newPlan
+      );
     }
     // Update team with new license data
     await this.stripeSubscriptionRepo.updateTeamById(metadata.hubId, {

--- a/src/modules/user-admin/repositories/user-admin.workspace.repository.ts
+++ b/src/modules/user-admin/repositories/user-admin.workspace.repository.ts
@@ -10,12 +10,18 @@ export class AdminWorkspaceRepository {
 
   async findWorkspaceById(workspaceId: string) {
     const workspaceObjectId = new ObjectId(workspaceId);
-    return this.db.collection("workspace").findOne({ _id: workspaceObjectId });
+    return this.db.collection("workspace").findOne({
+      _id: workspaceObjectId,
+      isRestricted: { $ne: true }, // allow only non-restricted workspaces
+    });
   }
 
   async findPaginated(query: any, sort: any, skip: number, limit: number) {
     const collection = this.db.collection("workspace");
-
+    query = {
+      ...query,
+      isRestricted: { $ne: true }, // allow false OR undefined only
+    };
     const total = await collection.countDocuments(query);
     const rawData = await collection
       .find(query)
@@ -28,8 +34,13 @@ export class AdminWorkspaceRepository {
   }
 
   async getTotalWorkspaceCount(query: any): Promise<number> {
+    query = {
+      ...query,
+      isRestricted: { $ne: true }, // exclude restricted workspaces
+    };
     return await this.db.collection("workspace").countDocuments(query);
   }
+
   async getFilteredCollectionsByIds({
     ids = [],
     search = "",

--- a/src/modules/workspace/repositories/workspace.repository.ts
+++ b/src/modules/workspace/repositories/workspace.repository.ts
@@ -157,12 +157,6 @@ export class WorkspaceRepository {
     id: ObjectId,
     updatedWorkspace: Partial<WorkspaceDtoForIdDocument>,
   ): Promise<WithId<Workspace>> {
-    const data = await this.getWorkspace(id.toString());
-    if (data?.isRestricted || data?.isFreezed) {
-      throw new BadRequestException(
-        "This workspace is restricted and cannot be accessed.",
-      );
-    }
     const response = await this.db
       .collection<Workspace>(Collections.WORKSPACE)
       .findOneAndUpdate(
@@ -263,12 +257,6 @@ export class WorkspaceRepository {
     environment: EnvironmentDto,
   ): Promise<UpdateResult> {
     const _id = new ObjectId(workspaceId);
-    const data = await this.getWorkspace(workspaceId);
-    if (data?.isRestricted || data?.isFreezed) {
-      throw new BadRequestException(
-        "This workspace is restricted and cannot be accessed.",
-      );
-    }
     return await this.db.collection(Collections.WORKSPACE).updateOne(
       { _id },
       {
@@ -334,12 +322,6 @@ export class WorkspaceRepository {
     testflow: TestflowInfoDto,
   ): Promise<UpdateResult> {
     const _id = new ObjectId(workspaceId);
-    const data = await this.getWorkspace(workspaceId);
-    if (data?.isRestricted || data?.isFreezed) {
-      throw new BadRequestException(
-        "This workspace is restricted and cannot be accessed.",
-      );
-    }
     const response = await this.db.collection(Collections.WORKSPACE).updateOne(
       { _id },
       {
@@ -396,12 +378,6 @@ export class WorkspaceRepository {
     name: string,
   ): Promise<UpdateResult> {
     const _id = new ObjectId(workspaceId);
-    const data = await this.getWorkspace(workspaceId);
-    if (data?.isRestricted || data?.isFreezed) {
-      throw new BadRequestException(
-        "This workspace is restricted and cannot be accessed.",
-      );
-    }
     const response = await this.db
       .collection(Collections.WORKSPACE)
       .updateOne(


### PR DESCRIPTION
### Description
I removed the function that retrieved workspaces based on a specific condition, since it was being used earlier. Now, the admin panel only displays workspaces that are unrestricted for the user.

### Add Issue Number
Fixes jira

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**