### PR TITLE
Support invite acceptance with auto-login and workspace context

### DIFF
--- a/src/modules/identity/controllers/auth.controller.ts
+++ b/src/modules/identity/controllers/auth.controller.ts
@@ -6,6 +6,7 @@ import {
   Get,
   Req,
   Res,
+  BadRequestException,
 } from "@nestjs/common";
 
 import {
@@ -25,6 +26,7 @@ import { UserService } from "../services/user.service";
 import { ObjectId } from "mongodb";
 import { ConfigService } from "@nestjs/config";
 import { HubSpotService } from "../services/hubspot.service";
+import { TeamUserService } from "../services/team-user.service";
 /**
  * Authentication Controller
  */
@@ -46,6 +48,7 @@ export class AuthController {
     private readonly authService: AuthService,
 
     private readonly userService: UserService,
+    private readonly teamUserService: TeamUserService,
     private readonly configService: ConfigService,
     private readonly hubspotService: HubSpotService,
   ) {}
@@ -188,6 +191,46 @@ export class AuthController {
     return res.redirect(
       HttpStatusCode.MOVED_PERMANENTLY,
       urlWithTokenAndSource,
+    );
+  }
+
+  @Post("invite/accept-and-login")
+  @ApiOperation({
+    summary: "Accept invite and login user",
+  })
+  async acceptInviteAndLogin(
+    @Body() body: { teamId: string; inviteId: string; email: string },
+    @Res() res: FastifyReply,
+  ) {
+    const { teamId, inviteId, email } = body;
+
+    const inviteResult = await this.teamUserService.acceptInviteByEmail(
+      inviteId,
+      teamId,
+      email,
+    );
+
+    const user = await this.userService.getUserByEmail(email);
+    if (!user) {
+      throw new BadRequestException("User not found after invite acceptance");
+    }
+
+    const [accessToken, refreshToken] = await Promise.all([
+      this.authService.createToken(user._id),
+      this.authService.createRefreshToken(user._id),
+    ]);
+
+    return res.status(HttpStatusCode.OK).send(
+      new ApiResponseService(
+        "Invite accepted & login successful",
+        HttpStatusCode.OK,
+        {
+          accessToken,
+          refreshToken,
+          teamId,
+          workspaces: inviteResult.workspaces,
+        },
+      ),
     );
   }
 }

--- a/src/modules/identity/controllers/auth.controller.ts
+++ b/src/modules/identity/controllers/auth.controller.ts
@@ -229,6 +229,7 @@ export class AuthController {
           refreshToken,
           teamId,
           workspaces: inviteResult.workspaces,
+          role: inviteResult.role,
         },
       ),
     );

--- a/src/modules/identity/controllers/auth.controller.ts
+++ b/src/modules/identity/controllers/auth.controller.ts
@@ -228,6 +228,7 @@ export class AuthController {
           accessToken,
           refreshToken,
           teamId,
+          teamName: inviteResult.teamName,
           workspaces: inviteResult.workspaces,
           role: inviteResult.role,
         },

--- a/src/modules/identity/services/team-user.service.ts
+++ b/src/modules/identity/services/team-user.service.ts
@@ -1289,6 +1289,7 @@ export class TeamUserService {
     // now remove it from invites array
     await this.removeTeamInvite(teamId, matchedInvite.email);
     return {
+      teamName: teamData.name,
       teamId: teamId,
       email: matchedInvite.email,
       role: matchedInvite.role,


### PR DESCRIPTION
### Description
What:
- Added a new API to accept team invites and log the user in.
- API returns accessToken, refreshToken, teamId, and workspaceId.
- API returns workspace name and hub name.

Why:
- Invite flow required three separate steps (accept invite + login + invited hub).
- Desktop deep link flow needs auth tokens and workspace context in one call.

How:
- Reused existing acceptInviteByEmail logic.
- Generated tokens using existing auth service.
- Included teamId to allow direct navigation after login.
- Include workspace name and hub name for pop-up

Covers:
- Case 1: Logged-out user auto-login after invite.
- Case 2: Redirect user to invited team/hub after login.
- Case 3: Open with pop-up contain information about invited workspaces, hub and role.

Tested:
- Invite acceptance via API.
- Token generation verified.
- workspaceId returned correctly.


### Add Issue Number
Task-14

### Add Screenshots/GIFs

https://github.com/user-attachments/assets/449a0db0-23e7-46ff-9c19-de02b0b2ac95


https://github.com/user-attachments/assets/82fdb1b9-5146-4ab9-a0aa-6043e8dfc735



### Add Known Issue
During login, multiple confirmation prompts sometimes appear in a loop for a few seconds.

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have linked an issue to the pull request.**
- [ ] **I have linked a PR type label to the pull request.**
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.