### PR TITLE
feat: Add super-admin role protection for admin hub APIs [SPRW-3087]

### DIFF
--- a/src/modules/billing/services/stripe-subscription.service.ts
+++ b/src/modules/billing/services/stripe-subscription.service.ts
@@ -671,7 +671,21 @@ export class StripeSubscriptionService {
       ),
     };
 
-    await this.updateTeamPlanWithBilling(metadata.hubId, plan, billingDetails);
+    // Get current team plan
+    const existingTeam = await this.stripeSubscriptionRepo.findTeamById(
+      metadata.hubId,
+    );
+
+    // Skip webhook overwrite ONLY if admin changed plan recently
+    if (existingTeam?.billing?.updatedBy === BillingSource.API_CALL) {
+      console.log("Skipping webhook overwrite due to admin plan change");
+    } else {
+      await this.updateTeamPlanWithBilling(
+        metadata.hubId,
+        plan,
+        billingDetails,
+      );
+    }
     if (!isDowngrading) {
       const teamIdObject = new ObjectId(metadata.hubId);
       const updateTeam =

--- a/src/modules/user-admin/controllers/user-admin.hubs.controller.ts
+++ b/src/modules/user-admin/controllers/user-admin.hubs.controller.ts
@@ -385,7 +385,7 @@ export class AdminHubsController {
   }
 
   @UseGuards(JwtAuthGuard, RolesGuard)
-  // @Roles("admin")
+  @Roles("super-admin")
   @ApiBearerAuth()
   @ApiOperation({ summary: "Extend trial period for a hub" })
   @ApiParam({
@@ -427,7 +427,7 @@ export class AdminHubsController {
   }
 
   @UseGuards(JwtAuthGuard, RolesGuard)
-  // @Roles("admin")
+  @Roles("super-admin")
   @ApiBearerAuth()
   @ApiOperation({ summary: "Add a subscription plan to a hub" })
   @ApiParam({
@@ -468,6 +468,7 @@ export class AdminHubsController {
   }
 
   @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles("super-admin")
   @ApiBearerAuth()
   @ApiOperation({ summary: "Change hub subscription plan (upgrade/downgrade)" })
   @ApiParam({

--- a/src/modules/user-admin/services/user-admin.hubs.service.ts
+++ b/src/modules/user-admin/services/user-admin.hubs.service.ts
@@ -669,6 +669,7 @@ export class AdminHubsService {
 
     const subscriptionId = stripeProvider?.subscriptionId;
 
+    // Update Stripe subscription if exists
     if (subscriptionId && !subscriptionId.startsWith("sub_test")) {
       await this.stripeSubscriptionService["stripeService"].updateSubscription(
         subscriptionId,
@@ -679,6 +680,7 @@ export class AdminHubsService {
           changeType,
           proratedAmount,
           effectiveDate,
+          updatedByAdmin: true,
         },
       );
     }


### PR DESCRIPTION
### Description
Implemented role-based access control for admin hub management APIs by restricting them to super-admin users using the @Roles("super-admin") guard.

This ensures that sensitive operations such as hub plan changes and other administrative actions can only be performed by users with super-admin privileges.

Additionally verified that plan update flows continue to work correctly with Stripe webhook processing without overriding admin-triggered changes.

### Add Issue Number
SPRW-3087
### Add Screenshots/GIFs

https://github.com/user-attachments/assets/adf09400-4c5b-4967-9252-4c7dc3b7444e


### Add Known Issue
If applicable, add any known issues.

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.